### PR TITLE
fix: parameter reference resolution during V3 upgrade

### DIFF
--- a/src/ByteBard.AsyncAPI.Readers/TempStorageKeys.cs
+++ b/src/ByteBard.AsyncAPI.Readers/TempStorageKeys.cs
@@ -7,5 +7,6 @@
         public const string OperationMessageReferences = "OperationMessageReferences";
         public const string ComponentMessages = "ComponentMessages";
         public const string ChannelAddresses = "ChannelAddresses";
+        public const string ParameterSchemaReferences = "ParameterSchemaReferences";
     }
 }

--- a/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiDocumentDeserializer.cs
+++ b/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiDocumentDeserializer.cs
@@ -67,6 +67,11 @@ namespace ByteBard.AsyncAPI.Readers
                 context.GetFromTempStorage<Dictionary<AsyncApiParameter, AsyncApiJsonSchemaReference>>(TempStorageKeys
                     .ParameterSchemaReferences);
 
+            if (parameterReferences == null)
+            {
+                return;
+            }
+
             foreach (var parameterReference in parameterReferences)
             {
                 var parameter = parameterReference.Key;
@@ -76,7 +81,7 @@ namespace ByteBard.AsyncAPI.Readers
                 {
                     continue;
                 }
-                
+
                 if (schema.Enum.Any())
                 {
                     parameter.Enum = schema.Enum.Select(e => e.GetValue<string>()).ToList();
@@ -93,7 +98,7 @@ namespace ByteBard.AsyncAPI.Readers
                 }
             }
         }
-        
+
         private static void SetMessages(ParsingContext context, AsyncApiDocument document)
         {
             var messages = context.GetFromTempStorage<Dictionary<string, AsyncApiMessage>>(TempStorageKeys.ComponentMessages);

--- a/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiDocumentDeserializer.cs
+++ b/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiDocumentDeserializer.cs
@@ -57,9 +57,43 @@ namespace ByteBard.AsyncAPI.Readers
             SetSecuritySchemeScopes(asyncApiNode.Context, document);
             SetMessages(asyncApiNode.Context, document);
             SetOperations(asyncApiNode.Context, document);
+            SetParameters(asyncApiNode.Context, document);
             return document;
         }
 
+        private static void SetParameters(ParsingContext context, AsyncApiDocument document)
+        {
+            var parameterReferences =
+                context.GetFromTempStorage<Dictionary<AsyncApiParameter, AsyncApiJsonSchemaReference>>(TempStorageKeys
+                    .ParameterSchemaReferences);
+
+            foreach (var parameterReference in parameterReferences)
+            {
+                var parameter = parameterReference.Key;
+                var multiFormatSchema = context.Workspace.ResolveReference<AsyncApiMultiFormatSchema>(parameterReference.Value.Reference);
+                var schema = multiFormatSchema.Schema.As<AsyncApiJsonSchema>();
+                if (schema == null)
+                {
+                    continue;
+                }
+                
+                if (schema.Enum.Any())
+                {
+                    parameter.Enum = schema.Enum.Select(e => e.GetValue<string>()).ToList();
+                }
+
+                if (schema.Default != null)
+                {
+                    parameter.Default = schema.Default.GetValue<string>();
+                }
+
+                if (schema.Examples.Any())
+                {
+                    parameter.Examples = schema.Examples.Select(e => e.GetValue<string>()).ToList();
+                }
+            }
+        }
+        
         private static void SetMessages(ParsingContext context, AsyncApiDocument document)
         {
             var messages = context.GetFromTempStorage<Dictionary<string, AsyncApiMessage>>(TempStorageKeys.ComponentMessages);

--- a/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiParameterDeserializer.cs
+++ b/src/ByteBard.AsyncAPI.Readers/V2/AsyncApiParameterDeserializer.cs
@@ -1,5 +1,6 @@
 namespace ByteBard.AsyncAPI.Readers
 {
+    using System.Collections.Generic;
     using ByteBard.AsyncAPI.Extensions;
     using ByteBard.AsyncAPI.Models;
     using ByteBard.AsyncAPI.Readers.ParseNodes;
@@ -23,6 +24,14 @@ namespace ByteBard.AsyncAPI.Readers
         private static void LoadParameterFromSchema(AsyncApiParameter instance, ParseNode node)
         {
             var schema = AsyncApiJsonSchemaDeserializer.LoadSchema(node);
+            if (schema is AsyncApiJsonSchemaReference schemaReference)
+            {
+                var existingReferences = node.Context.GetFromTempStorage<Dictionary<AsyncApiParameter, AsyncApiJsonSchemaReference>>(TempStorageKeys.ParameterSchemaReferences) ?? new Dictionary<AsyncApiParameter, AsyncApiJsonSchemaReference>();
+                existingReferences.Add(instance, schemaReference);
+                node.Context.SetTempStorage(TempStorageKeys.ParameterSchemaReferences, existingReferences);
+                return;
+            }
+
             if (schema.Enum.Any())
             {
                 instance.Enum = schema.Enum.Select(e => e.GetValue<string>()).ToList();

--- a/test/ByteBard.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -1304,5 +1304,89 @@ namespace ByteBard.AsyncAPI.Tests
 
             Assert.AreEqual("this mah binding", httpBinding.Headers.Description);
         }
+        
+        [Test]
+        public void V2_DocumentWithParameterReference_ResolvesToParameter()
+        {
+            var input = """
+                        {
+                            "asyncapi": "2.6.0",
+                            "info": {
+                                "title": "NikolajApi",
+                                "description": "Trying to work with enum in parameter",
+                                "contact": {
+                                    "url": "https://github.com/Nikolajls",
+                                    "name": "Nikolaj",
+                                    "email": "test@test.com"
+                                },
+                                "version": "0.0.1"
+                            },
+                            "servers": {
+                                "integration-pulsar": {
+                                    "url": "pulsar+ssl://localhost:6651",
+                                    "protocol": "pulsar+ssl"
+                                }
+                            },
+                            "channels": {
+                                "v1.Room.{roomId}.Opened": {
+                                    "publish": {
+                                        "description": "Publish a message about a room being opened",
+                                        "operationId": "pub-room",
+                                        "message": {
+                                            "$ref": "#/components/messages/RoomOpened"
+                                        }
+                                    },
+                                    "parameters": {
+                                        "roomId": {
+                                            "schema": {
+                                                "$ref": "#/components/schemas/Rooms"
+                                            },
+                                            "description": "The ID of the room"
+                                        }
+                                    }
+                                }
+                            },
+                            "components": {
+                                "schemas": {
+                                    "RoomOpened": {
+                                        "type": "object",
+                                        "properties": {
+                                            "roomName": {
+                                                "type": "string",
+                                                "examples": [
+                                                    "ABC"
+                                                ]
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "Rooms": {
+                                        "enum": [
+                                            "123",
+                                            "245",
+                                            "678"
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "messages": {
+                                    "RoomOpened": {
+                                        "name": "RoomOpened",
+                                        "summary": "Message indicating a room has been opened",
+                                        "contentType": "application/json",
+                                        "payload": {
+                                            "$ref": "#/components/schemas/RoomOpened"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """;
+
+            var document = new AsyncApiStringReader().Read(input, out var diagnostic);
+            diagnostic.Errors.Should().BeEmpty();
+            diagnostic.Warnings.Should().BeEmpty();
+            document.Channels.First().Value.Parameters.First().Value.Enum.Should().HaveCount(3);
+        }
     }
 }


### PR DESCRIPTION
## About the PR
in V3 the Parameter Schema does not exist anymore.
The code was missing the path for upgrading from a parameter schema reference, to a V3 parameter.

The solution was to simply defer to later using tempstorage.

When re-serializing the schema reference will be destroyed though.

### Changelog
- Add: tempstorage for parameter schema references from V2.

### Related Issues
- Closes #14
