### PR TITLE
fix: try read relative uri's as files.

### DIFF
--- a/src/ByteBard.AsyncAPI.Readers/AsyncApiJsonDocumentReader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/AsyncApiJsonDocumentReader.cs
@@ -280,7 +280,7 @@ namespace ByteBard.AsyncAPI.Readers
                 }
                 else
                 {
-                    stream = loader.Load(new Uri(reference.Reference.ExternalResource, UriKind.RelativeOrAbsolute));
+                    stream = loader.Load(this.settings.BaseUri, new Uri(reference.Reference.ExternalResource, UriKind.RelativeOrAbsolute));
                     this.context.Workspace.RegisterComponent(reference.Reference.ExternalResource, stream);
                 }
 
@@ -310,7 +310,7 @@ namespace ByteBard.AsyncAPI.Readers
                 }
                 else
                 {
-                    stream = await loader.LoadAsync(new Uri(reference.Reference.ExternalResource, UriKind.RelativeOrAbsolute));
+                    stream = await loader.LoadAsync(this.settings.BaseUri, new Uri(reference.Reference.ExternalResource, UriKind.RelativeOrAbsolute));
                     this.context.Workspace.RegisterComponent(reference.Reference.ExternalResource, stream);
                 }
 

--- a/src/ByteBard.AsyncAPI.Readers/AsyncApiReaderSettings.cs
+++ b/src/ByteBard.AsyncAPI.Readers/AsyncApiReaderSettings.cs
@@ -71,6 +71,11 @@ namespace ByteBard.AsyncAPI.Readers
         public bool LeaveStreamOpen { get; set; }
 
         /// <summary>
+        /// Uri where relative references should be resolved from when using the External Reference Loader.
+        /// </summary>
+        public Uri? BaseUri { get; set; }
+        
+        /// <summary>
         /// External reference reader implementation provided by users for reading external resources.
         /// </summary>
         public IStreamLoader ExternalReferenceLoader { get; set; } = null;

--- a/src/ByteBard.AsyncAPI.Readers/Interface/IStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Interface/IStreamLoader.cs
@@ -6,8 +6,8 @@ namespace ByteBard.AsyncAPI.Readers.Interface
 
     public interface IStreamLoader
     {
-        Task<Stream> LoadAsync(Uri uri);
+        Task<Stream> LoadAsync(Uri baseUri, Uri uri);
 
-        Stream Load(Uri uri);
+        Stream Load(Uri baseUri, Uri uri);
     }
 }

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -20,7 +20,7 @@
                     switch (uri.Scheme.ToLowerInvariant())
                     {
                         case "file":
-                            return File.OpenRead(uri.AbsolutePath);
+                            return File.OpenRead(uri.LocalPath);
                         case "http":
                         case "https":
                             return HttpClient.GetStreamAsync(uri).GetAwaiter().GetResult();

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -48,7 +48,7 @@
                     switch (uri.Scheme.ToLowerInvariant())
                     {
                         case "file":
-                            return File.OpenRead(uri.AbsolutePath);
+                            return File.OpenRead(uri.LocalPath);
                         case "http":
                         case "https":
                             return await HttpClient.GetStreamAsync(uri);

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -43,7 +43,7 @@
         {
             try
             {
-                if (uri.IsAbsoluteUri && !string.IsNullOrEmpty(uri.Scheme))
+                if (uri.IsAbsoluteUri)
                 {
                     switch (uri.Scheme.ToLowerInvariant())
                     {

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -11,7 +11,7 @@
     {
         private static readonly HttpClient HttpClient = new HttpClient();
 
-        public Stream Load(Uri uri)
+        public Stream Load(Uri baseUri, Uri uri)
         {
             try
             {
@@ -30,7 +30,7 @@
                 }
                 else
                 {
-                    return File.OpenRead(uri.OriginalString);
+                    return File.OpenRead(new Uri(baseUri, uri).LocalPath);
                 }
             }
             catch (Exception ex)
@@ -39,7 +39,7 @@
             }
         }
 
-        public async Task<Stream> LoadAsync(Uri uri)
+        public async Task<Stream> LoadAsync(Uri baseUri, Uri uri)
         {
             try
             {
@@ -58,7 +58,7 @@
                 }
                 else
                 {
-                    return File.OpenRead(uri.OriginalString);
+                    return File.OpenRead(new Uri(baseUri, uri).LocalPath);
                 }
             }
             catch (Exception ex)

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -51,7 +51,7 @@
                             return File.OpenRead(uri.AbsolutePath);
                         case "http":
                         case "https":
-                            return HttpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
+                            return await HttpClient.GetStreamAsync(uri);
                         default:
                             throw new ArgumentException("Unsupported scheme");
                     }

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -15,7 +15,7 @@
         {
             try
             {
-                if (uri.IsAbsoluteUri && !string.IsNullOrEmpty(uri.Scheme))
+                if (uri.IsAbsoluteUri)
                 {
                     switch (uri.Scheme.ToLowerInvariant())
                     {

--- a/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
+++ b/src/ByteBard.AsyncAPI.Readers/Services/DefaultStreamLoader.cs
@@ -15,20 +15,27 @@
         {
             try
             {
-                switch (uri.Scheme)
+                if (uri.IsAbsoluteUri && !string.IsNullOrEmpty(uri.Scheme))
                 {
-                    case "file":
-                        return File.OpenRead(uri.AbsolutePath);
-                    case "http":
-                    case "https":
-                        return HttpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
-                    default:
-                        throw new ArgumentException("Unsupported scheme");
+                    switch (uri.Scheme.ToLowerInvariant())
+                    {
+                        case "file":
+                            return File.OpenRead(uri.AbsolutePath);
+                        case "http":
+                        case "https":
+                            return HttpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
+                        default:
+                            throw new ArgumentException("Unsupported scheme");
+                    }
+                }
+                else
+                {
+                    return File.OpenRead(uri.OriginalString);
                 }
             }
             catch (Exception ex)
             {
-                throw new AsyncApiReaderException($"Something went wrong trying to fetch '{uri.OriginalString}. {ex.Message}'", ex);
+                throw new AsyncApiReaderException($"Something went wrong trying to fetch '{uri.OriginalString}'. {ex.Message}", ex);
             }
         }
 
@@ -36,15 +43,22 @@
         {
             try
             {
-                switch (uri.Scheme)
+                if (uri.IsAbsoluteUri && !string.IsNullOrEmpty(uri.Scheme))
                 {
-                    case "file":
-                        return File.OpenRead(uri.AbsolutePath);
-                    case "http":
-                    case "https":
-                        return await HttpClient.GetStreamAsync(uri);
-                    default:
-                        throw new ArgumentException("Unsupported scheme");
+                    switch (uri.Scheme.ToLowerInvariant())
+                    {
+                        case "file":
+                            return File.OpenRead(uri.AbsolutePath);
+                        case "http":
+                        case "https":
+                            return HttpClient.GetStreamAsync(uri).GetAwaiter().GetResult();
+                        default:
+                            throw new ArgumentException("Unsupported scheme");
+                    }
+                }
+                else
+                {
+                    return File.OpenRead(uri.OriginalString);
                 }
             }
             catch (Exception ex)

--- a/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiReference_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiReference_Should.cs
@@ -525,7 +525,7 @@ namespace ByteBard.AsyncAPI.Tests
 
         private readonly string input;
 
-        public Stream Load(Uri uri)
+        public Stream Load(Uri baseUri, Uri uri)
         {
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
@@ -535,9 +535,9 @@ namespace ByteBard.AsyncAPI.Tests
             return stream;
         }
 
-        public Task<Stream> LoadAsync(Uri uri)
+        public Task<Stream> LoadAsync(Uri baseUri, Uri uri)
         {
-            return Task.FromResult(this.Load(uri));
+            return Task.FromResult(this.Load(baseUri, uri));
         }
     }
 
@@ -564,7 +564,7 @@ namespace ByteBard.AsyncAPI.Tests
                 description: Light intensity measured in lumens.
             """;
 
-        public Stream Load(Uri uri)
+        public Stream Load(Uri baseUri, Uri uri)
         {
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
@@ -581,9 +581,9 @@ namespace ByteBard.AsyncAPI.Tests
             return stream;
         }
 
-        public Task<Stream> LoadAsync(Uri uri)
+        public Task<Stream> LoadAsync(Uri baseUri, Uri uri)
         {
-            return Task.FromResult(this.Load(uri));
+            return Task.FromResult(this.Load(baseUri, uri));
         }
     }
 }


### PR DESCRIPTION
## About the PR
There is a bug, where the Uri is relative and fails `.Scheme` throws and leaves us in the catch.

### Related Issues
- Closes #20 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable base URI setting for resolving relative external references.

* **Bug Fixes**
  * Improved stream loading to correctly distinguish absolute vs relative URIs and reliably handle file, http and https schemes.
  * Clarified error messages to give clearer feedback when loading fails.

* **Refactor**
  * Unified sync/async stream-loading behavior and error handling for consistent results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->