### PR TITLE
fix: add `ApplicableVersions` property to validation rules

### DIFF
--- a/src/ByteBard.AsyncAPI/Validation/AsyncApiValidator.cs
+++ b/src/ByteBard.AsyncAPI/Validation/AsyncApiValidator.cs
@@ -198,11 +198,27 @@ namespace ByteBard.AsyncAPI.Validations
                 type = typeof(IAsyncApiReferenceable);
             }
 
-            var rules = this.ruleSet.FindRules(type);
+            var version = this.GetDocumentVersion();
+            var rules = this.ruleSet.FindRules(type, version);
             foreach (var rule in rules)
             {
                 rule.Evaluate(this as IValidationContext, item);
             }
+        }
+
+        private AsyncApiVersion? GetDocumentVersion()
+        {
+            if (this.RootDocument?.Asyncapi?.StartsWith("2") == true)
+            {
+                return AsyncApiVersion.AsyncApi2_0;
+            }
+
+            if (this.RootDocument?.Asyncapi?.StartsWith("3") == true)
+            {
+                return AsyncApiVersion.AsyncApi3_0;
+            }
+
+            return null;
         }
     }
 }

--- a/src/ByteBard.AsyncAPI/Validation/AsyncApiValidator.cs
+++ b/src/ByteBard.AsyncAPI/Validation/AsyncApiValidator.cs
@@ -14,6 +14,7 @@ namespace ByteBard.AsyncAPI.Validations
         private readonly ValidationRuleSet ruleSet;
         private readonly IList<AsyncApiValidatorError> errors = new List<AsyncApiValidatorError>();
         private readonly IList<AsyncApiValidatorWarning> warnings = new List<AsyncApiValidatorWarning>();
+        private AsyncApiVersion? documentVersion;
 
         /// <summary>
         /// Create a vistor that will validate an AsyncApiDocument.
@@ -23,6 +24,7 @@ namespace ByteBard.AsyncAPI.Validations
         {
             this.ruleSet = ruleSet;
             this.RootDocument = rootDocument;
+            this.documentVersion = this.GetDocumentVersion();
         }
 
         public AsyncApiDocument RootDocument { get; }
@@ -198,8 +200,7 @@ namespace ByteBard.AsyncAPI.Validations
                 type = typeof(IAsyncApiReferenceable);
             }
 
-            var version = this.GetDocumentVersion();
-            var rules = this.ruleSet.FindRules(type, version);
+            var rules = this.ruleSet.FindRules(type, this.documentVersion);
             foreach (var rule in rules)
             {
                 rule.Evaluate(this as IValidationContext, item);

--- a/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiDocumentRules.cs
+++ b/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiDocumentRules.cs
@@ -1,4 +1,4 @@
-﻿namespace ByteBard.AsyncAPI.Validation.Rules
+namespace ByteBard.AsyncAPI.Validation.Rules
 {
     using System;
     using System.Collections.Generic;
@@ -73,6 +73,22 @@
                                 "ServerKeys",
                                 string.Format(Resource.Validation_KeyMustMatchRegularExpr, key, "servers", keyRegex.ToString()));
                         }
+                    }
+
+                    context.Exit();
+                });
+
+        [AsyncApiVersionRule(AsyncApiVersion.AsyncApi2_0)]
+        public static ValidationRule<AsyncApiDocument> V2ChannelsRequired =>
+            new ValidationRule<AsyncApiDocument>(
+                (context, document) =>
+                {
+                    context.Enter("channels");
+                    if (document.Channels == null || document.Channels.Count == 0)
+                    {
+                        context.CreateError(
+                                nameof(DocumentRequiredFields),
+                                string.Format(Resource.Validation_FieldRequired, "channels", "document"));
                     }
 
                     context.Exit();

--- a/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiOperationRules.cs
+++ b/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiOperationRules.cs
@@ -10,6 +10,7 @@ namespace ByteBard.AsyncAPI.Validation.Rules
     [AsyncApiRule]
     public static class AsyncApiOperationRules
     {
+        [AsyncApiVersionRule(AsyncApiVersion.AsyncApi3_0)]
         public static ValidationRule<AsyncApiOperation> OperationRequiredFields =>
             new ValidationRule<AsyncApiOperation>(
                 (context, operation) =>
@@ -35,6 +36,7 @@ namespace ByteBard.AsyncAPI.Validation.Rules
                     context.Exit();
                 });
 
+        [AsyncApiVersionRule(AsyncApiVersion.AsyncApi3_0)]
         public static ValidationRule<AsyncApiOperation> OperationChannelReference =>
             new ValidationRule<AsyncApiOperation>(
                 (context, operation) =>
@@ -56,6 +58,7 @@ namespace ByteBard.AsyncAPI.Validation.Rules
                     }
                 });
 
+        [AsyncApiVersionRule(AsyncApiVersion.AsyncApi3_0)]
         public static ValidationRule<AsyncApiOperation> OperationMessages =>
             new ValidationRule<AsyncApiOperation>(
                 (context, operation) =>

--- a/src/ByteBard.AsyncAPI/Validation/ValidationRule.cs
+++ b/src/ByteBard.AsyncAPI/Validation/ValidationRule.cs
@@ -13,6 +13,12 @@ namespace ByteBard.AsyncAPI.Validations
         internal abstract Type ElementType { get; }
 
         /// <summary>
+        /// Gets or sets the AsyncAPI versions this rule applies to.
+        /// Null means the rule applies to all versions.
+        /// </summary>
+        public AsyncApiVersion[] ApplicableVersions { get; internal set; }
+
+        /// <summary>
         /// Validate the object.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/ByteBard.AsyncAPI/Validation/ValidationRuleSet.cs
+++ b/src/ByteBard.AsyncAPI/Validation/ValidationRuleSet.cs
@@ -31,6 +31,25 @@ namespace ByteBard.AsyncAPI.Validations
         }
 
         /// <summary>
+        /// Retrieve the rules that are related to a specific type and version.
+        /// </summary>
+        /// <param name="type">The type that is to be validated.</param>
+        /// <param name="version">The AsyncAPI version to filter rules by. If null, all rules are returned.</param>
+        /// <returns>Either the rules related to the type and version, or an empty list.</returns>
+        public IList<ValidationRule> FindRules(Type type, AsyncApiVersion? version)
+        {
+            var allRules = this.FindRules(type);
+            if (version == null)
+            {
+                return allRules;
+            }
+
+            return allRules.Where(r =>
+                r.ApplicableVersions == null ||
+                r.ApplicableVersions.Contains(version.Value)).ToList();
+        }
+
+        /// <summary>
         /// Gets the default validation rule sets.
         /// </summary>
         /// <remarks>
@@ -161,19 +180,25 @@ namespace ByteBard.AsyncAPI.Validations
             ValidationRuleSet ruleSet = new ValidationRuleSet();
             Type validationRuleType = typeof(ValidationRule);
 
-            IEnumerable<PropertyInfo> rules = typeof(ValidationRuleSet).Assembly.GetTypes()
+            IEnumerable<PropertyInfo> ruleProperties = typeof(ValidationRuleSet).Assembly.GetTypes()
                 .Where(t => t.IsClass
                             && t != typeof(object)
                             && t.GetCustomAttributes(typeof(AsyncApiRuleAttribute), false).Any())
                 .SelectMany(t2 => t2.GetProperties(BindingFlags.Static | BindingFlags.Public)
                                 .Where(p => validationRuleType.IsAssignableFrom(p.PropertyType)));
 
-            foreach (var property in rules)
+            foreach (var property in ruleProperties)
             {
                 var propertyValue = property.GetValue(null); // static property
                 ValidationRule rule = propertyValue as ValidationRule;
                 if (rule != null)
                 {
+                    var versionAttribute = property.GetCustomAttribute<AsyncApiVersionRuleAttribute>();
+                    if (versionAttribute != null)
+                    {
+                        rule.ApplicableVersions = versionAttribute.Versions;
+                    }
+
                     ruleSet.Add(rule);
                 }
             }
@@ -185,5 +210,16 @@ namespace ByteBard.AsyncAPI.Validations
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class AsyncApiRuleAttribute : Attribute
     {
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class AsyncApiVersionRuleAttribute : Attribute
+    {
+        public AsyncApiVersion[] Versions { get; }
+
+        public AsyncApiVersionRuleAttribute(params AsyncApiVersion[] versions)
+        {
+            Versions = versions;
+        }
     }
 }

--- a/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
@@ -2,11 +2,105 @@
 
 using System.Linq;
 using FluentAssertions;
+using ByteBard.AsyncAPI.Models;
 using ByteBard.AsyncAPI.Readers;
+using ByteBard.AsyncAPI.Validations;
 using NUnit.Framework;
 
 public class ValidationRuleTests
 {
+  [Test]
+  public void V2_DocumentWithNoChannels_ShouldError()
+  {
+    // arrange
+    var input =
+      """
+      asyncapi: 2.6.0
+      info:
+        title: Chat Application
+        version: 1.0.0
+      """;
+
+    // act
+    new AsyncApiStringReader().Read(input, out var diagnostic);
+
+    // assert
+    diagnostic.Errors.Should().Contain(e => e.Message == "The field 'channels' in 'document' object is REQUIRED.");
+  }
+
+  [Test]
+  public void V2_DocumentWithChannels_ShouldPass()
+  {
+    // arrange
+    var input =
+      """
+      asyncapi: 2.6.0
+      info:
+        title: Chat Application
+        version: 1.0.0
+      channels:
+        chat:
+          publish:
+            operationId: onMessageReceived
+            message:
+              name: text
+              payload:
+                type: string
+      """;
+
+    // act
+    new AsyncApiStringReader().Read(input, out var diagnostic);
+
+    // assert
+    diagnostic.Errors.Should().NotContain(e => e.Message.Contains("channels"));
+  }
+
+  [Test]
+  public void V3_DocumentWithNoChannels_ShouldPass()
+  {
+    // arrange
+    var input =
+      """
+      asyncapi: 3.0.0
+      info:
+        title: Chat Application
+        version: 1.0.0
+      """;
+
+    // act
+    new AsyncApiStringReader().Read(input, out var diagnostic);
+
+    // assert
+    diagnostic.Errors.Should().NotContain(e => e.Message.Contains("channels") && e.Message.Contains("REQUIRED"));
+  }
+
+  [Test]
+  public void VersionAwareRuleSet_V2Rule_DoesNotRunOnV3Document()
+  {
+    // arrange
+    var document = new AsyncApiDocument { Asyncapi = "3.0.0", Info = new AsyncApiInfo { Title = "Test", Version = "1.0.0" } };
+    var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
+
+    // act
+    var rules = ruleSet.FindRules(typeof(AsyncApiDocument), AsyncApiVersion.AsyncApi3_0);
+
+    // assert
+    rules.Should().NotContain(r => r.ApplicableVersions != null && r.ApplicableVersions.Contains(AsyncApiVersion.AsyncApi2_0) && !r.ApplicableVersions.Contains(AsyncApiVersion.AsyncApi3_0));
+  }
+
+  [Test]
+  public void VersionAwareRuleSet_V3Rule_DoesNotRunOnV2Document()
+  {
+    // arrange
+    var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
+
+    // act
+    var rules = ruleSet.FindRules(typeof(AsyncApiOperation), AsyncApiVersion.AsyncApi2_0);
+
+    // assert
+    rules.Should().NotContain(r => r.ApplicableVersions != null && r.ApplicableVersions.Contains(AsyncApiVersion.AsyncApi3_0) && !r.ApplicableVersions.Contains(AsyncApiVersion.AsyncApi2_0));
+  }
+
   [Test]
   public void V2_OperationId_WithNonUniqueKey_DiagnosticsError()
   {

--- a/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
@@ -77,10 +77,7 @@ public class ValidationRuleTests
   [Test]
   public void VersionAwareRuleSet_V2Rule_DoesNotRunOnV3Document()
   {
-   public void VersionAwareRuleSet_V2Rule_DoesNotRunOnV3Document()
-   {
-     // arrange
-     var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
+    // arrange
     var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
 
     // act

--- a/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRuleTests.cs
@@ -77,8 +77,10 @@ public class ValidationRuleTests
   [Test]
   public void VersionAwareRuleSet_V2Rule_DoesNotRunOnV3Document()
   {
-    // arrange
-    var document = new AsyncApiDocument { Asyncapi = "3.0.0", Info = new AsyncApiInfo { Title = "Test", Version = "1.0.0" } };
+   public void VersionAwareRuleSet_V2Rule_DoesNotRunOnV3Document()
+   {
+     // arrange
+     var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
     var ruleSet = ValidationRuleSet.GetDefaultRuleSet();
 
     // act

--- a/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRulesetTests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Validation/ValidationRulesetTests.cs
@@ -33,7 +33,7 @@
             Assert.IsNotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.AreEqual(27, rules.Count);
+            Assert.AreEqual(28, rules.Count);
         }
     }
 }


### PR DESCRIPTION
Added a new public property `AsyncApiVersion[] ApplicableVersions` in the base class `ValidationRule`.
Updated existing rule classes (`OperationRequiredFields`, etc.) with `[AsyncApiVersionRule]` attributes.
Modified `ValidationRuleSet` to set applicable versions for each rule based on custom attribute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented version-aware validation rules that apply based on AsyncAPI document version (v2 vs v3).
  * Added validation requirement ensuring channels field is present in AsyncAPI v2 documents.

* **Bug Fixes**
  * Fixed validation context management to properly exit validation scopes during rule execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->