### PR TITLE
refactor(bindings)!: binding serialization for AsyncAPI v2/v3

### DIFF
--- a/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPChannelBinding.cs
@@ -53,9 +53,16 @@
             { "vhost", (a, n) => { a.Vhost = n.GetScalarValue(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPMessageBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPMessageBinding.cs
@@ -20,6 +20,16 @@
         /// </summary>
         public string MessageType { get; set; }
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/AMQP/AMQPOperationBinding.cs
@@ -72,9 +72,16 @@
             { "ack", (a, n) => { a.Ack = n.GetBooleanValue(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
@@ -1,6 +1,7 @@
 namespace ByteBard.AsyncAPI.Bindings.Http
 {
     using System;
+    using System.Net;
     using ByteBard.AsyncAPI.Models;
     using ByteBard.AsyncAPI.Readers;
     using ByteBard.AsyncAPI.Readers.ParseNodes;
@@ -9,31 +10,24 @@ namespace ByteBard.AsyncAPI.Bindings.Http
     /// <summary>
     /// Binding class for http messaging channels.
     /// </summary>
+    /// <remarks>
+    /// The 'statusCode' field exists in AsyncAPI V3 but not in V2.
+    /// </remarks>
     public class HttpMessageBinding : MessageBinding<HttpMessageBinding>
     {
+        private const string V2BindingVersion = "0.2.0";
+        private const string V3BindingVersion = "0.3.0";
+
         /// <summary>
         /// A Schema object containing the definitions for HTTP-specific headers. This schema MUST be of type object and have a properties key.
         /// </summary>
         public AsyncApiJsonSchema Headers { get; set; }
 
         /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
+        /// The HTTP response status code according to RFC 9110. `statusCode` is only relevant for messages referenced by the Operation Reply Object.
+        /// Note: This field is only serialized in AsyncAPI V3.
         /// </summary>
-        public override void SerializeProperties(IAsyncApiWriter writer)
-        {
-            if (writer is null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-
-            writer.WriteStartObject();
-
-            writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV2(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion);
-            writer.WriteExtensions(this.Extensions);
-
-            writer.WriteEndObject();
-        }
+        public HttpStatusCode? StatusCode { get; set; }
 
         public override string BindingKey => "http";
 
@@ -41,6 +35,46 @@ namespace ByteBard.AsyncAPI.Bindings.Http
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
             { "headers", (a, n) => { a.Headers = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
+            { "statusCode", (a, n) => { a.StatusCode = (HttpStatusCode)int.Parse(n.GetScalarValue()); } },
         };
+
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStartObject();
+            writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV2(w));
+            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion ?? V2BindingVersion);
+            writer.WriteExtensions(this.Extensions);
+            writer.WriteEndObject();
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStartObject();
+            writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV3(w));
+
+            if (this.StatusCode.HasValue)
+            {
+                writer.WriteRequiredProperty(AsyncApiConstants.StatusCode, (int)this.StatusCode.Value);
+            }
+
+            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion ?? V3BindingVersion);
+            writer.WriteExtensions(this.Extensions);
+            writer.WriteEndObject();
+        }
+
+        public override void SerializeProperties(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
     }
 }

--- a/src/ByteBard.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Http/HttpMessageBinding.cs
@@ -35,7 +35,14 @@ namespace ByteBard.AsyncAPI.Bindings.Http
         {
             { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
             { "headers", (a, n) => { a.Headers = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
-            { "statusCode", (a, n) => { a.StatusCode = (HttpStatusCode)int.Parse(n.GetScalarValue()); } },
+            { "statusCode", (a, n) =>
+                {
+                    if (int.TryParse(n.GetScalarValue(), out var code))
+                    {
+                        a.StatusCode = (HttpStatusCode)code;
+                    }
+                }
+            },
         };
 
         public override void SerializeV2(IAsyncApiWriter writer)

--- a/src/ByteBard.AsyncAPI.Bindings/Http/HttpOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Http/HttpOperationBinding.cs
@@ -10,8 +10,17 @@ namespace ByteBard.AsyncAPI.Bindings.Http
     /// <summary>
     /// Binding class for http operations.
     /// </summary>
+    /// <remarks>
+    /// The 'type' field exists in AsyncAPI V2 but is removed in V3 (inferred from operation action).
+    /// </remarks>
     public class HttpOperationBinding : OperationBinding<HttpOperationBinding>
     {
+        private const string V2BindingVersion = "0.2.0";
+        private const string V3BindingVersion = "0.3.0";
+
+        /// <summary>
+        /// Represents the HTTP operation type (used in V2 serialization).
+        /// </summary>
         public enum HttpOperationType
         {
             [Display("request")]
@@ -22,12 +31,7 @@ namespace ByteBard.AsyncAPI.Bindings.Http
         }
 
         /// <summary>
-        /// REQUIRED. Type of operation. Its value MUST be either request or response.
-        /// </summary>
-        public HttpOperationType? Type { get; set; }
-
-        /// <summary>
-        /// When type is request, this is the HTTP method, otherwise it MUST be ignored. Its value MUST be one of GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, CONNECT, and TRACE.
+        /// The HTTP method, e.g. GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, CONNECT, and TRACE.
         /// </summary>
         public string Method { get; set; }
 
@@ -36,10 +40,16 @@ namespace ByteBard.AsyncAPI.Bindings.Http
         /// </summary>
         public AsyncApiJsonSchema Query { get; set; }
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
-        public override void SerializeProperties(IAsyncApiWriter writer)
+        public override string BindingKey => "http";
+
+        protected override FixedFieldMap<HttpOperationBinding> FixedFieldMap => new()
+        {
+            { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
+            { "method", (a, n) => { a.Method = n.GetScalarValue(); } },
+            { "query", (a, n) => { a.Query = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
+        };
+
+        public override void SerializeV2(IAsyncApiWriter writer)
         {
             if (writer is null)
             {
@@ -48,22 +58,50 @@ namespace ByteBard.AsyncAPI.Bindings.Http
 
             writer.WriteStartObject();
 
-            writer.WriteRequiredProperty(AsyncApiConstants.Type, this.Type.GetDisplayName());
+            var typeValue = this.InferTypeFromContext(writer);
+            if (typeValue.HasValue)
+            {
+                writer.WriteRequiredProperty(AsyncApiConstants.Type, typeValue.GetDisplayName());
+            }
+
             writer.WriteOptionalProperty(AsyncApiConstants.Method, this.Method);
             writer.WriteOptionalObject(AsyncApiConstants.Query, this.Query, (w, h) => h.SerializeV2(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion);
+            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion ?? V2BindingVersion);
             writer.WriteExtensions(this.Extensions);
             writer.WriteEndObject();
         }
 
-        protected override FixedFieldMap<HttpOperationBinding> FixedFieldMap => new()
+        public override void SerializeV3(IAsyncApiWriter writer)
         {
-            { "bindingVersion", (a, n) => { a.BindingVersion = n.GetScalarValue(); } },
-            { "type", (a, n) => { a.Type = n.GetScalarValue().GetEnumFromDisplayName<HttpOperationType>(); } },
-            { "method", (a, n) => { a.Method = n.GetScalarValue(); } },
-            { "query", (a, n) => { a.Query = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
-        };
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
 
-        public override string BindingKey => "http";
+            writer.WriteStartObject();
+            writer.WriteOptionalProperty(AsyncApiConstants.Method, this.Method);
+            writer.WriteOptionalObject(AsyncApiConstants.Query, this.Query, (w, h) => h.SerializeV3(w));
+            writer.WriteOptionalProperty(AsyncApiConstants.BindingVersion, this.BindingVersion ?? V3BindingVersion);
+            writer.WriteExtensions(this.Extensions);
+            writer.WriteEndObject();
+        }
+
+        public override void SerializeProperties(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        private HttpOperationType? InferTypeFromContext(IAsyncApiWriter writer)
+        {
+            var parentOperation = writer.Workspace?.GetSerializationContext<AsyncApiOperation>();
+            if (parentOperation == null)
+            {
+                return null;
+            }
+
+            return parentOperation.Action == AsyncApiAction.Send
+                ? HttpOperationType.Request
+                : HttpOperationType.Response;
+        }
     }
 }

--- a/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaChannelBinding.cs
@@ -54,9 +54,16 @@ namespace ByteBard.AsyncAPI.Bindings.Kafka
             { "confluent.value.subject.name.strategy", (a, n) => { a.ConfluentValueSubjectName = n.GetScalarValue(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaMessageBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaMessageBinding.cs
@@ -35,6 +35,16 @@
         /// The version of this binding. If omitted, "latest" MUST be assumed.
         /// </summary>
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)
@@ -53,12 +63,6 @@
 
             writer.WriteEndObject();
         }
-
-        /// <summary>
-        /// Serializes the v2.
-        /// </summary>
-        /// <param name="writer">The writer.</param>
-        /// <exception cref="ArgumentNullException">writer.</exception>
 
         public override string BindingKey => "kafka";
 

--- a/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaOperationBinding.cs
@@ -30,9 +30,16 @@ namespace ByteBard.AsyncAPI.Bindings.Kafka
             { "clientId", (a, n) => { a.ClientId = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaServerBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Kafka/KafkaServerBinding.cs
@@ -29,9 +29,16 @@ namespace ByteBard.AsyncAPI.Bindings.Kafka
             { "schemaRegistryVendor", (a, n) => { a.SchemaRegistryVendor = n.GetScalarValue(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTMessageBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTMessageBinding.cs
@@ -33,6 +33,16 @@
         /// </summary>
         public string ResponseTopic { get; set; }
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTOperationBinding.cs
@@ -34,9 +34,16 @@
             { "messageExpiryInterval", (a, n) => { a.MessageExpiryInterval = n.GetIntegerValueOrDefault(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTServerBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/MQTT/MQTTServerBinding.cs
@@ -66,9 +66,16 @@
             { "retain", (a, n) => { a.Retain = n.GetBooleanValue(); } },
         };
 
-        /// <summary>
-        /// Serialize to AsyncAPI V2 document without using reference.
-        /// </summary>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Pulsar/PulsarChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Pulsar/PulsarChannelBinding.cs
@@ -46,6 +46,16 @@
 
         public override string BindingKey => "pulsar";
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Pulsar/PulsarServerBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Pulsar/PulsarServerBinding.cs
@@ -23,6 +23,16 @@
             { "tenant", (a, n) => { a.Tenant = n.GetScalarValue(); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Sns/SnsChannelBinding.cs
@@ -61,7 +61,16 @@ namespace ByteBard.AsyncAPI.Bindings.Sns
             { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
-        /// <inheritdoc/>
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Sns/SnsOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Sns/SnsOperationBinding.cs
@@ -73,6 +73,16 @@ namespace ByteBard.AsyncAPI.Bindings.Sns
             { "maxReceivesPerSecond", (a, n) => { a.MaxReceivesPerSecond = n.GetIntegerValue(); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Sqs/SqsChannelBinding.cs
@@ -68,6 +68,16 @@ namespace ByteBard.AsyncAPI.Bindings.Sqs
             { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/Sqs/SqsOperationBinding.cs
@@ -60,6 +60,16 @@ namespace ByteBard.AsyncAPI.Bindings.Sqs
             { "condition", (a, n) => { a.Condition = Condition.Parse(n); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI.Bindings/WebSockets/WebSocketsChannelBinding.cs
+++ b/src/ByteBard.AsyncAPI.Bindings/WebSockets/WebSocketsChannelBinding.cs
@@ -33,6 +33,16 @@ namespace ByteBard.AsyncAPI.Bindings.WebSockets
             { "headers", (a, n) => { a.Headers = AsyncApiJsonSchemaDeserializer.LoadSchema(n); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             if (writer is null)

--- a/src/ByteBard.AsyncAPI/AsyncApiWorkspace.cs
+++ b/src/ByteBard.AsyncAPI/AsyncApiWorkspace.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using ByteBard.AsyncAPI.Models;
     using ByteBard.AsyncAPI.Models.Interfaces;
 
@@ -12,6 +13,23 @@
         private readonly Dictionary<Uri, IAsyncApiSerializable> resolvedReferenceRegistry = new();
 
         public AsyncApiDocument RootDocument { get; private set; }
+
+        /// <summary>
+        /// Stack for tracking parent context during serialization.
+        /// Allows bindings to access their parent operation, channel, or message.
+        /// </summary>
+        public Stack<object> SerializationContext { get; } = new();
+
+        /// <summary>
+        /// Gets the first item of the specified type from the serialization context.
+        /// </summary>
+        /// <typeparam name="T">The type to find in the context.</typeparam>
+        /// <returns>The first matching item, or default if not found.</returns>
+        public T GetSerializationContext<T>()
+            where T : class
+        {
+            return this.SerializationContext.OfType<T>().FirstOrDefault();
+        }
 
         public void RegisterComponents(AsyncApiDocument document)
         {

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiBinding.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiBinding.cs
@@ -13,25 +13,9 @@
 
         public string BindingVersion { get; set; }
 
-        public void SerializeV2(IAsyncApiWriter writer)
-        {
-            this.SerializeCore(writer);
-        }
+        public abstract void SerializeV2(IAsyncApiWriter writer);
 
-        public void SerializeV3(IAsyncApiWriter writer)
-        {
-            this.SerializeCore(writer);
-        }
-
-        private void SerializeCore(IAsyncApiWriter writer)
-        {
-            if (writer is null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-
-            this.SerializeProperties(writer);
-        }
+        public abstract void SerializeV3(IAsyncApiWriter writer);
 
         public abstract void SerializeProperties(IAsyncApiWriter writer);
     }

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiBindings{TBinding}.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiBindings{TBinding}.cs
@@ -13,16 +13,6 @@
 
         public virtual void SerializeV2(IAsyncApiWriter writer)
         {
-            this.SerializeCore(writer);
-        }
-
-        public virtual void SerializeV3(IAsyncApiWriter writer)
-        {
-            this.SerializeCore(writer);
-        }
-
-        private void SerializeCore(IAsyncApiWriter writer)
-        {
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
@@ -38,6 +28,29 @@
                 writer.WritePropertyName(bindingType);
 
                 bindingValue.SerializeV2(writer);
+            }
+
+            writer.WriteExtensions(this.Extensions);
+            writer.WriteEndObject();
+        }
+
+        public virtual void SerializeV3(IAsyncApiWriter writer)
+        {
+            if (writer is null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            writer.WriteStartObject();
+
+            foreach (var binding in this)
+            {
+                var bindingType = binding.Key;
+                var bindingValue = binding.Value;
+
+                writer.WritePropertyName(bindingType);
+
+                bindingValue.SerializeV3(writer);
             }
 
             writer.WriteExtensions(this.Extensions);

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiChannel.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiChannel.cs
@@ -75,41 +75,49 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-
-            // description
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-
-            // servers
-            writer.WriteOptionalCollection(AsyncApiConstants.Servers, this.Servers.Select(s => s.Reference.FragmentId).ToList(), (w, s) => w.WriteValue(s));
-
-            var operations = writer.Workspace.RootDocument?.Operations.Values.Where(operation => CheckOperationChannel(operation, writer)).ToList();
-
-            // subscribe (Now Send)
-            writer.WriteOptionalObject(AsyncApiConstants.Subscribe, operations?.FirstOrDefault(o => o.Action == AsyncApiAction.Send), (w, s) => s?.SerializeV2(w));
-
-            // publish (Now Receive)
-            writer.WriteOptionalObject(AsyncApiConstants.Publish, operations?.FirstOrDefault(o => o.Action == AsyncApiAction.Receive), (w, s) => s?.SerializeV2(w));
-
-            // parameters
-            writer.WriteOptionalMap(AsyncApiConstants.Parameters, this.Parameters, (writer, key, component) =>
+            writer.Workspace?.SerializationContext.Push(this);
+            try
             {
-                if (component is AsyncApiParameterReference reference)
+                writer.WriteStartObject();
+
+                // description
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+
+                // servers
+                writer.WriteOptionalCollection(AsyncApiConstants.Servers, this.Servers.Select(s => s.Reference.FragmentId).ToList(), (w, s) => w.WriteValue(s));
+
+                var operations = writer.Workspace.RootDocument?.Operations.Values.Where(operation => CheckOperationChannel(operation, writer)).ToList();
+
+                // subscribe (Now Send)
+                writer.WriteOptionalObject(AsyncApiConstants.Subscribe, operations?.FirstOrDefault(o => o.Action == AsyncApiAction.Send), (w, s) => s?.SerializeV2(w));
+
+                // publish (Now Receive)
+                writer.WriteOptionalObject(AsyncApiConstants.Publish, operations?.FirstOrDefault(o => o.Action == AsyncApiAction.Receive), (w, s) => s?.SerializeV2(w));
+
+                // parameters
+                writer.WriteOptionalMap(AsyncApiConstants.Parameters, this.Parameters, (writer, key, component) =>
                 {
-                    reference.SerializeV2(writer);
-                }
-                else
-                {
-                    component.SerializeV2(writer);
-                }
-            });
+                    if (component is AsyncApiParameterReference reference)
+                    {
+                        reference.SerializeV2(writer);
+                    }
+                    else
+                    {
+                        component.SerializeV2(writer);
+                    }
+                });
 
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
 
-            // extensions
-            writer.WriteExtensions(this.Extensions);
+                // extensions
+                writer.WriteExtensions(this.Extensions);
 
-            writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
+            finally
+            {
+                writer.Workspace?.SerializationContext.Pop();
+            }
         }
 
         public virtual void SerializeV3(IAsyncApiWriter writer)
@@ -119,25 +127,33 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-
-            writer.WriteOptionalProperty(AsyncApiConstants.Address, this.Address);
-            writer.WriteRequiredMap(AsyncApiConstants.Messages, this.Messages, (w, k, m) => m.SerializeV3(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
-            writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-            writer.WriteOptionalCollection(AsyncApiConstants.Servers, this.Servers, (w, s) => s.Reference.SerializeV3(w));
-            if (this.Address.IsChannelAddressExpression())
+            writer.Workspace?.SerializationContext.Push(this);
+            try
             {
-                writer.WriteOptionalMap(AsyncApiConstants.Parameters, this.Parameters, (w, key, p) => p.SerializeV3(w));
+                writer.WriteStartObject();
+
+                writer.WriteOptionalProperty(AsyncApiConstants.Address, this.Address);
+                writer.WriteRequiredMap(AsyncApiConstants.Messages, this.Messages, (w, k, m) => m.SerializeV3(w));
+                writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
+                writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+                writer.WriteOptionalCollection(AsyncApiConstants.Servers, this.Servers, (w, s) => s.Reference.SerializeV3(w));
+                if (this.Address.IsChannelAddressExpression())
+                {
+                    writer.WriteOptionalMap(AsyncApiConstants.Parameters, this.Parameters, (w, key, p) => p.SerializeV3(w));
+                }
+
+                writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, s) => s.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
+                writer.WriteExtensions(this.Extensions);
+
+                writer.WriteEndObject();
             }
-
-            writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, s) => s.SerializeV2(w));
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
-            writer.WriteExtensions(this.Extensions);
-
-            writer.WriteEndObject();
+            finally
+            {
+                writer.Workspace?.SerializationContext.Pop();
+            }
         }
 
         private bool CheckOperationChannel(AsyncApiOperation operation, IAsyncApiWriter writer)

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiChannel.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiChannel.cs
@@ -144,8 +144,8 @@
                 }
 
                 writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
-                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, s) => s.SerializeV2(w));
-                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, s) => s.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV3(w));
                 writer.WriteExtensions(this.Extensions);
 
                 writer.WriteEndObject();

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiConstants.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiConstants.cs
@@ -114,6 +114,7 @@
         public const string SchemaFormat = "schemaFormat";
         public const string ContentType = "contentType";
         public const string BindingVersion = "bindingVersion";
+        public const string StatusCode = "statusCode";
         public const string Key = "key";
         public const string Method = "method";
         public const string SchemaIdPayloadEncoding = "schemaIdPayloadEncoding";

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiMessage.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiMessage.cs
@@ -88,25 +88,33 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-            writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.Schema.SerializeV2(w));
-            writer.WriteOptionalObject(AsyncApiConstants.Payload, this.Payload, (w, p) => p.SerializeV2(w));
-            writer.WriteOptionalObject(AsyncApiConstants.CorrelationId, this.CorrelationId, (w, c) => c.SerializeV2(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.SchemaFormat, this.Payload?.SchemaFormat);
-            writer.WriteOptionalProperty(AsyncApiConstants.ContentType, this.ContentType);
-            writer.WriteOptionalProperty(AsyncApiConstants.Name, this.Name);
-            writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
-            writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-            writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV2(w));
-            writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV2(w));
+            writer.Workspace?.SerializationContext.Push(this);
+            try
+            {
+                writer.WriteStartObject();
+                writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.Schema.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Payload, this.Payload, (w, p) => p.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.CorrelationId, this.CorrelationId, (w, c) => c.SerializeV2(w));
+                writer.WriteOptionalProperty(AsyncApiConstants.SchemaFormat, this.Payload?.SchemaFormat);
+                writer.WriteOptionalProperty(AsyncApiConstants.ContentType, this.ContentType);
+                writer.WriteOptionalProperty(AsyncApiConstants.Name, this.Name);
+                writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
+                writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+                writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV2(w));
 
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Examples, this.Examples, (w, e) => e.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Examples, this.Examples, (w, e) => e.SerializeV2(w));
 
-            writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV2(w));
-            writer.WriteExtensions(this.Extensions);
-            writer.WriteEndObject();
+                writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV2(w));
+                writer.WriteExtensions(this.Extensions);
+                writer.WriteEndObject();
+            }
+            finally
+            {
+                writer.Workspace?.SerializationContext.Pop();
+            }
         }
 
         public virtual void SerializeV3(IAsyncApiWriter writer)
@@ -116,24 +124,32 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-            writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.Payload, this.Payload, (w, p) => p.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.CorrelationId, this.CorrelationId, (w, c) => c.SerializeV3(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.ContentType, this.ContentType);
-            writer.WriteOptionalProperty(AsyncApiConstants.Name, this.Name);
-            writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
-            writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-            writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV3(w));
+            writer.Workspace?.SerializationContext.Push(this);
+            try
+            {
+                writer.WriteStartObject();
+                writer.WriteOptionalObject(AsyncApiConstants.Headers, this.Headers, (w, h) => h.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Payload, this.Payload, (w, p) => p.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.CorrelationId, this.CorrelationId, (w, c) => c.SerializeV3(w));
+                writer.WriteOptionalProperty(AsyncApiConstants.ContentType, this.ContentType);
+                writer.WriteOptionalProperty(AsyncApiConstants.Name, this.Name);
+                writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
+                writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+                writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV3(w));
 
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Examples, this.Examples, (w, e) => e.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Examples, this.Examples, (w, e) => e.SerializeV3(w));
 
-            writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV3(w));
-            writer.WriteExtensions(this.Extensions);
-            writer.WriteEndObject();
+                writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV3(w));
+                writer.WriteExtensions(this.Extensions);
+                writer.WriteEndObject();
+            }
+            finally
+            {
+                writer.Workspace?.SerializationContext.Pop();
+            }
         }
     }
 }

--- a/src/ByteBard.AsyncAPI/Models/AsyncApiOperation.cs
+++ b/src/ByteBard.AsyncAPI/Models/AsyncApiOperation.cs
@@ -80,33 +80,41 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-
-            // writer.WriteOptionalProperty(AsyncApiConstants.OperationId, this.OperationId);
-            writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-            writer.WriteOptionalCollection(AsyncApiConstants.Security, this.Security, (w, t) => this.SerializeAsSecurityRequirement(t, w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV2(w));
-            writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV2(w));
-
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV2(w));
-            IEnumerable<AsyncApiMessage> messages = this.Messages.Any() ? this.Messages : this.Channel?.Messages.Values;
-
-            if (messages?.Count() > 1)
+            writer.Workspace?.SerializationContext.Push(this);
+            try
             {
-                writer.WritePropertyName(AsyncApiConstants.Message);
                 writer.WriteStartObject();
-                writer.WriteOptionalCollection(AsyncApiConstants.OneOf, messages, (w, t) => t.SerializeV2(w));
+
+                // writer.WriteOptionalProperty(AsyncApiConstants.OperationId, this.OperationId);
+                writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+                writer.WriteOptionalCollection(AsyncApiConstants.Security, this.Security, (w, t) => this.SerializeAsSecurityRequirement(t, w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV2(w));
+
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV2(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV2(w));
+                IEnumerable<AsyncApiMessage> messages = this.Messages.Any() ? this.Messages : this.Channel?.Messages.Values;
+
+                if (messages?.Count() > 1)
+                {
+                    writer.WritePropertyName(AsyncApiConstants.Message);
+                    writer.WriteStartObject();
+                    writer.WriteOptionalCollection(AsyncApiConstants.OneOf, messages, (w, t) => t.SerializeV2(w));
+                    writer.WriteEndObject();
+                }
+                else
+                {
+                    writer.WriteOptionalObject(AsyncApiConstants.Message, messages?.FirstOrDefault(), (w, m) => m.SerializeV2(w));
+                }
+
+                writer.WriteExtensions(this.Extensions);
                 writer.WriteEndObject();
             }
-            else
+            finally
             {
-                writer.WriteOptionalObject(AsyncApiConstants.Message, messages?.FirstOrDefault(), (w, m) => m.SerializeV2(w));
+                writer.Workspace?.SerializationContext.Pop();
             }
-
-            writer.WriteExtensions(this.Extensions);
-            writer.WriteEndObject();
         }
 
         public virtual void SerializeV3(IAsyncApiWriter writer)
@@ -116,21 +124,29 @@
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            writer.WriteStartObject();
-            writer.WriteRequiredProperty(AsyncApiConstants.Action, this.Action.GetDisplayName());
-            writer.WriteRequiredObject(AsyncApiConstants.Channel, this.Channel, (w, c) => c.Reference.SerializeV3(w));
-            writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
-            writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
-            writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
-            writer.WriteOptionalCollection(AsyncApiConstants.Security, this.Security, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV3(w));
-            writer.WriteOptionalCollection(AsyncApiConstants.Messages, this.Messages, (w, m) => m.Reference.SerializeV3(w));
-            writer.WriteOptionalObject(AsyncApiConstants.Reply, this.Reply, (w, t) => t.SerializeV3(w));
-            writer.WriteExtensions(this.Extensions);
-            writer.WriteEndObject();
+            writer.Workspace?.SerializationContext.Push(this);
+            try
+            {
+                writer.WriteStartObject();
+                writer.WriteRequiredProperty(AsyncApiConstants.Action, this.Action.GetDisplayName());
+                writer.WriteRequiredObject(AsyncApiConstants.Channel, this.Channel, (w, c) => c.Reference.SerializeV3(w));
+                writer.WriteOptionalProperty(AsyncApiConstants.Title, this.Title);
+                writer.WriteOptionalProperty(AsyncApiConstants.Summary, this.Summary);
+                writer.WriteOptionalProperty(AsyncApiConstants.Description, this.Description);
+                writer.WriteOptionalCollection(AsyncApiConstants.Security, this.Security, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Tags, this.Tags, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.ExternalDocs, this.ExternalDocs, (w, e) => e.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Bindings, this.Bindings, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Traits, this.Traits, (w, t) => t.SerializeV3(w));
+                writer.WriteOptionalCollection(AsyncApiConstants.Messages, this.Messages, (w, m) => m.Reference.SerializeV3(w));
+                writer.WriteOptionalObject(AsyncApiConstants.Reply, this.Reply, (w, t) => t.SerializeV3(w));
+                writer.WriteExtensions(this.Extensions);
+                writer.WriteEndObject();
+            }
+            finally
+            {
+                writer.Workspace?.SerializationContext.Pop();
+            }
         }
 
         private void SerializeAsSecurityRequirement(AsyncApiSecurityScheme scheme, IAsyncApiWriter w)

--- a/test/ByteBard.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
+++ b/test/ByteBard.AsyncAPI.Tests/AsyncApiDocumentV2Tests.cs
@@ -1208,6 +1208,7 @@ namespace ByteBard.AsyncAPI.Tests
                           http:
                             headers:
                               description: this mah binding
+                            bindingVersion: 0.2.0
                           kafka:
                             key:
                               description: this mah other binding

--- a/test/ByteBard.AsyncAPI.Tests/Bindings/CustomBinding_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Bindings/CustomBinding_Should.cs
@@ -48,6 +48,16 @@
             { "nestedConfiguration", (a, n) => { a.NestedConfiguration = n.ParseMapWithExtensions(NestedConfiguration.FixedFieldMap); } },
         };
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             writer.WriteStartObject();

--- a/test/ByteBard.AsyncAPI.Tests/Bindings/Http/HttpBindings_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Bindings/Http/HttpBindings_Should.cs
@@ -1,5 +1,7 @@
 ﻿namespace ByteBard.AsyncAPI.Tests.Bindings.Http
 {
+    using System.Linq;
+    using System.Net;
     using FluentAssertions;
     using ByteBard.AsyncAPI.Bindings;
     using ByteBard.AsyncAPI.Bindings.Http;
@@ -19,6 +21,7 @@
                   http:
                     headers:
                       description: this mah binding
+                    bindingVersion: 0.2.0
                 """;
 
             var message = new AsyncApiMessage();
@@ -29,6 +32,7 @@
                 {
                     Description = "this mah binding",
                 },
+                BindingVersion = "0.2.0",
             });
 
             // Act
@@ -44,41 +48,146 @@
         }
 
         [Test]
-        public void V2_HttpOperationBinding_FilledObject_SerializesAndDeserializes()
+        public void V2_HttpOperationBinding_RoundTrip_PreservesTypeFromOperationAction()
         {
             // Arrange
-            var expected =
+            var input =
                 """
-                bindings:
-                  http:
-                    type: request
-                    method: POST
-                    query:
-                      description: this mah query
+                asyncapi: 2.6.0
+                info:
+                  title: Test
+                  version: 1.0.0
+                channels:
+                  test:
+                    subscribe:
+                      bindings:
+                        http:
+                          type: request
+                          method: POST
+                          query:
+                            description: query params
+                          bindingVersion: 0.2.0
                 """;
 
-            var operation = new AsyncApiOperation();
+            // Act
+            var settings = new AsyncApiReaderSettings();
+            settings.Bindings = BindingsCollection.Http;
+            var document = new AsyncApiStringReader(settings).Read(input, out _);
+            var output = document.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
+
+            // Assert
+            var httpBinding = document.Operations.Values.First().Bindings["http"] as HttpOperationBinding;
+            httpBinding.Method.Should().Be("POST");
+            httpBinding.Query.Description.Should().Be("query params");
+
+            output.Should().Contain("type: request");
+            output.Should().Contain("method: POST");
+            output.Should().Contain("bindingVersion: 0.2.0");
+        }
+
+        [Test]
+        public void V2_HttpOperationBinding_RoundTrip_InfersResponseTypeFromPublishAction()
+        {
+            // Arrange
+            var input =
+                """
+                asyncapi: 2.6.0
+                info:
+                  title: Test
+                  version: 1.0.0
+                channels:
+                  test:
+                    publish:
+                      bindings:
+                        http:
+                          type: response
+                """;
+
+            // Act
+            var settings = new AsyncApiReaderSettings();
+            settings.Bindings = BindingsCollection.Http;
+            var document = new AsyncApiStringReader(settings).Read(input, out _);
+            var output = document.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
+
+            // Assert
+            var operation = document.Operations.Values.First();
+            operation.Action.Should().Be(AsyncApiAction.Receive);
+
+            output.Should().Contain("type: response");
+            output.Should().Contain("bindingVersion: 0.2.0");
+        }
+
+        [Test]
+        public void V3_HttpOperationBinding_OmitsTypeField()
+        {
+            // Arrange
+            var operation = new AsyncApiOperation
+            {
+                Action = AsyncApiAction.Send,
+            };
 
             operation.Bindings.Add(new HttpOperationBinding
             {
-                Type = HttpOperationBinding.HttpOperationType.Request,
                 Method = "POST",
                 Query = new AsyncApiJsonSchema
                 {
-                    Description = "this mah query",
+                    Description = "query params",
                 },
             });
 
             // Act
-            var actual = operation.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
-            var settings = new AsyncApiReaderSettings();
-            settings.Bindings = BindingsCollection.Http;
-            var binding = new AsyncApiStringReader(settings).ReadFragment<AsyncApiOperation>(actual, AsyncApiVersion.AsyncApi2_0, out _);
+            var actual = operation.SerializeAsYaml(AsyncApiVersion.AsyncApi3_0);
 
             // Assert
-            actual.Should()
-                  .BePlatformAgnosticEquivalentTo(expected);
-            binding.Should().BeEquivalentTo(operation);
+            actual.Should().NotContain("type:");
+            actual.Should().Contain("method: POST");
+            actual.Should().Contain("bindingVersion: 0.3.0");
+        }
+
+        [Test]
+        public void V3_HttpMessageBinding_IncludesStatusCode()
+        {
+            // Arrange
+            var message = new AsyncApiMessage();
+
+            message.Bindings.Add(new HttpMessageBinding
+            {
+                Headers = new AsyncApiJsonSchema
+                {
+                    Description = "response headers",
+                },
+                StatusCode = HttpStatusCode.OK,
+            });
+
+            // Act
+            var actual = message.SerializeAsYaml(AsyncApiVersion.AsyncApi3_0);
+
+            // Assert
+            actual.Should().Contain("statusCode: 200");
+            actual.Should().Contain("bindingVersion: 0.3.0");
+        }
+
+        [Test]
+        public void V2_HttpMessageBinding_OmitsStatusCode()
+        {
+            // Arrange
+            var message = new AsyncApiMessage();
+
+            message.Bindings.Add(new HttpMessageBinding
+            {
+                Headers = new AsyncApiJsonSchema
+                {
+                    Description = "response headers",
+                },
+                StatusCode = HttpStatusCode.OK,
+            });
+
+            // Act
+            var actual = message.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
+
+            // Assert
+            actual.Should().NotContain("statusCode");
+            actual.Should().Contain("bindingVersion: 0.2.0");
         }
     }
 }

--- a/test/ByteBard.AsyncAPI.Tests/Bindings/StringOrStringList_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Bindings/StringOrStringList_Should.cs
@@ -131,6 +131,16 @@ namespace ByteBard.AsyncAPI.Tests.Bindings
 
         public override string BindingKey => "testBinding";
 
+        public override void SerializeV2(IAsyncApiWriter writer)
+        {
+            this.SerializeV3(writer);
+        }
+
+        public override void SerializeV3(IAsyncApiWriter writer)
+        {
+            this.SerializeProperties(writer);
+        }
+
         public override void SerializeProperties(IAsyncApiWriter writer)
         {
             writer.WriteStartObject();

--- a/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiMessage_Should.cs
@@ -282,6 +282,7 @@
                       examples:
                         - cKey: c
                           dKey: 1
+                    bindingVersion: 0.2.0
                 examples:
                   - payload:
                       PropA: a
@@ -379,6 +380,7 @@
                     {
                         "http", new HttpMessageBinding
                         {
+                            BindingVersion = "0.2.0",
                             Headers = new AsyncApiJsonSchema
                             {
                                 Title = "SchemaTitle",

--- a/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiOperation_Should.cs
+++ b/test/ByteBard.AsyncAPI.Tests/Models/AsyncApiOperation_Should.cs
@@ -238,6 +238,7 @@ namespace ByteBard.AsyncAPI.Tests.Models
         [Test]
         public void V2_AsyncApiOperation_WithBindings_Serializes()
         {
+            // Arrange
             var expected =
                 """
                 bindings:
@@ -246,6 +247,7 @@ namespace ByteBard.AsyncAPI.Tests.Models
                     method: PUT
                     query:
                       description: some query
+                    bindingVersion: 0.2.0
                   kafka:
                     groupId:
                       description: some Id
@@ -255,12 +257,12 @@ namespace ByteBard.AsyncAPI.Tests.Models
 
             var operation = new AsyncApiOperation
             {
+                Action = AsyncApiAction.Send,
                 Bindings = new AsyncApiBindings<IOperationBinding>
                 {
                     {
                         new HttpOperationBinding
                         {
-                            Type = HttpOperationBinding.HttpOperationType.Request,
                             Method = "PUT",
                             Query = new AsyncApiJsonSchema
                             {
@@ -284,6 +286,7 @@ namespace ByteBard.AsyncAPI.Tests.Models
                 },
             };
 
+            // Act
             var actual = operation.SerializeAsYaml(AsyncApiVersion.AsyncApi2_0);
 
             // Assert


### PR DESCRIPTION
Consolidates binding serialization logic for AsyncAPI v2 and v3.

The change introduces `SerializeV2` and `SerializeV3` methods in binding classes, deprecating the old `SerializeProperties` to streamline the serialization process. Additionally, it adds a `SerializationContext` to the `AsyncApiWorkspace` to enable bindings to access parent context during serialization.

This addresses inconsistencies in binding serialization across different AsyncAPI versions, and allows http bindings to serialize according to the spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP message binding now supports statusCode in AsyncAPI 3.0 and exposes bindingVersion for HTTP bindings (v2: 0.2.0, v3: 0.3.0)

* **Improvements**
  * Unified and more consistent serialization flow across AsyncAPI v2/v3 for bindings and operations
  * Serialization now uses a workspace context stack to preserve object context and inference for V2 operation type

* **Tests**
  * Updated tests to validate bindingVersion, statusCode behavior, and V2/V3 serialization differences
<!-- end of auto-generated comment: release notes by coderabbit.ai -->