### PR TITLE
ci: fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, edited, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint-pr-title:
     name: Lint PR title


### PR DESCRIPTION
Potential fix for [https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/4](https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/4)

Add an explicit `permissions` block at the workflow level (right after `on:` block and before `jobs:`) to enforce least privilege for all jobs in this workflow.

Best minimal permissions for current behavior:
- `contents: read` (safe baseline, common for actions metadata/repo reads)
- `pull-requests: write` (required for creating/updating/deleting sticky PR comments)

This preserves existing functionality (linting PR title + posting/removing PR comment) while preventing broader default token scopes from being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
