### PR TITLE
fix: correct rules for name requirement

### DIFF
--- a/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiSecuritySchemaRules.cs
+++ b/src/ByteBard.AsyncAPI/Validation/Rules/AsyncApiSecuritySchemaRules.cs
@@ -96,7 +96,7 @@ namespace ByteBard.AsyncAPI.Validation.Rules
 
         private static readonly Dictionary<string, Func<AsyncApiSecurityScheme, bool>> RequiredFieldsByType = new()
         {
-            { "name", sc => sc.Type is SecuritySchemeType.ApiKey },
+            { "name", sc => sc.Type is SecuritySchemeType.HttpApiKey },
             { "in", sc => sc.Type is SecuritySchemeType.ApiKey or SecuritySchemeType.HttpApiKey },
             { "scheme", sc => sc.Type is SecuritySchemeType.Http },
             { "flows", sc => sc.Type is SecuritySchemeType.OAuth2 },


### PR DESCRIPTION
## About the PR
@VisualBean  i found small bug when working on signalr client for scalar. the validation require name on Api not Http Api key, which is wrong against the async api schema 

### Changelog
- breaking: adjusted validation rule for http api key / api key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected security scheme validation so the `name` field is enforced for the appropriate scheme type (now applies to HTTP API key).
  * Kept all other security scheme validation rules unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->