### PR TITLE
fix: for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os:  [ windows-latest, macos-latest ]


### PR DESCRIPTION
Potential fix for [https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/3](https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/3)

Add an explicit `permissions` block to the `build` job in `.github/workflows/ci.yml`, setting only the minimum needed scope.  
For this job, the best minimal safe setting is:

- `contents: read`

This preserves existing functionality (checkout + .NET build/test) while ensuring the token cannot write unless explicitly granted later.

Change location:
- File: `.github/workflows/ci.yml`
- Region: under `jobs.build`, alongside `runs-on` and before `strategy`/`steps`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration permissions to use read-only access for repository contents.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->