### PR TITLE
fix: for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize, edited, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   block:
     name: Block if do not merge


### PR DESCRIPTION
Potential fix for [https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/2](https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/do_not_merge.yml` so the `GITHUB_TOKEN` is restricted to least privilege for all jobs in this workflow.  
Best single fix without changing behavior: set `permissions: { contents: read }` at workflow root (between `on:` and `jobs:`). This preserves functionality for a label-check workflow while avoiding inherited broad write scopes. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
