### PR TITLE
fix: for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -7,6 +7,11 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   first-interaction:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/1](https://github.com/ByteBardOrg/AsyncAPI.NET/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/first-interaction.yml` to enforce least privilege for this workflow.  
Best approach without changing functionality: define permissions at the workflow root (applies to all jobs) with only what this action needs to comment on issues/PRs:

- `contents: read` (safe baseline)
- `issues: write` (needed for issue welcome comment)
- `pull-requests: write` (needed for PR welcome comment)

Edit region: near the top of the file, after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
